### PR TITLE
Fix yfinance threading race condition causing price data mixing

### DIFF
--- a/backend/app/endpoints/portfolio.py
+++ b/backend/app/endpoints/portfolio.py
@@ -62,7 +62,9 @@ async def _safe_yfinance_download(symbols, start, end, progress=False, auto_adju
     
     async with _yfinance_lock:
         def _download_sync():
-            return yf.download(symbols, start=start, end=end, progress=progress, auto_adjust=auto_adjust)
+            # threads=False prevents yfinance's internal threading which uses a shared _DFS dictionary
+            # that can cause data to get mixed between symbols (see yfinance issue #2557)
+            return yf.download(symbols, start=start, end=end, progress=progress, auto_adjust=auto_adjust, threads=False)
         
         try:
             loop = asyncio.get_running_loop()


### PR DESCRIPTION
Historical stock prices were being incorrectly mixed between different symbols (e.g., SMH showing ~20 instead of ~370, META showing GOOGL's price of ~312).

Root cause: yfinance's internal threading uses a shared global `_DFS` dictionary that isn't thread-safe. Even with an asyncio lock preventing concurrent Python async calls, yfinance internally spawns its own threads when downloading multiple symbols, which still access this shared dictionary.

The fix adds `threads=False` to all `yf.download()` calls, forcing yfinance to download sequentially within each call and eliminating the internal race condition. This maintains the external asyncio lock for Python-level serialization while also disabling yfinance's problematic internal threading.

See yfinance issue #2557 for more details on this known issue.